### PR TITLE
Renombreado el archivo de ejecucion de dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ FROM openjdk:17-jdk-slim
 
 EXPOSE 8080
 
-COPY --from=build /build/libs/demo-1.jar app.jar
+COPY --from=build /build/libs/activos-0.0.1-SNAPSHOT.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
Corrigiendo el renombre del archivo construido por java. error en produccion 